### PR TITLE
Using the C++ Embedder API to  start and stop Node

### DIFF
--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -12,6 +12,32 @@
 #include "node.h"
 #include "bridge.h"
 
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+#include "cppgc/platform.h"
+#include "node.h"
+#include "uv.h"
+
+#include <algorithm>
+
+// Note: This file is being referred to from doc/api/embedding.md, and excerpts
+// from it are included in the documentation. Try to keep these in sync.
+// Snapshot support is not part of the embedder API docs yet due to its
+// experimental nature, although it is of course documented in node.h.
+
+using node::CommonEnvironmentSetup;
+using node::Environment;
+using node::MultiIsolatePlatform;
+using v8::Context;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Locker;
+using v8::MaybeLocal;
+using v8::V8;
+using v8::Value;
+
 const char* AdbTag = "NodeJS-Engine";
 
 // Forward declaration.
@@ -67,6 +93,102 @@ Java_net_hampoelz_capacitor_nodejs_NodeProcess_nativeSend(
     // Release the JNI references.
     env->ReleaseStringUTFChars(channelName, nativeChannel);
     env->ReleaseStringUTFChars(channelMessage, nativeMessage);
+}
+
+
+static Environment *nodeENV;
+
+int RunNodeInstance(MultiIsolatePlatform* platform,
+                    const std::vector<std::string>& args,
+                    const std::vector<std::string>& exec_args) {
+    int exit_code = 0;
+
+    // Setup up a libuv event loop, v8::Isolate, and Node.js Environment.
+    std::vector<std::string> errors;
+    std::unique_ptr<CommonEnvironmentSetup> setup =
+            CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);
+    if (!setup) {
+        for (const std::string& err : errors)
+            fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
+        return 1;
+    }
+
+    Isolate* isolate = setup->isolate();
+    nodeENV = setup->env();
+
+    {
+        Locker locker(isolate);
+        Isolate::Scope isolate_scope(isolate);
+        HandleScope handle_scope(isolate);
+        // The v8::Context needs to be entered when node::CreateEnvironment() and
+        // node::LoadEnvironment() are being called.
+        Context::Scope context_scope(setup->context());
+
+        // Set up the Node.js instance for execution, and run code inside of it.
+        // There is also a variant that takes a callback and provides it with
+        // the `require` and `process` objects, so that it can manually compile
+        // and run scripts as needed.
+        // The `require` function inside this script does *not* access the file
+        // system, and can only load built-in Node.js modules.
+        // `module.createRequire()` is being used to create one that is able to
+        // load files from the disk, and uses the standard CommonJS file loader
+        // instead of the internal-only `require` function.
+        MaybeLocal<Value> loadenv_ret = node::LoadEnvironment(
+                nodeENV,
+                "const publicRequire ="
+                "  require('node:module').createRequire(process.cwd() + '/');"
+                "globalThis.require = publicRequire;"
+                "require('node:vm').runInThisContext(process.argv[1]);");
+
+        if (loadenv_ret.IsEmpty())  // There has been a JS exception.
+            return 1;
+
+        exit_code = node::SpinEventLoop(nodeENV).FromMaybe(1);
+
+        // node::Stop() can be used to explicitly stop the event loop and keep
+        // further JavaScript from running. It can be called from any thread,
+        // and will act like worker.terminate() if called from another thread.
+        node::Stop(nodeENV);
+    }
+
+    return exit_code;
+}
+
+int RunNodeProcess(int argc, char** argv) {
+    argv = uv_setup_args(argc, argv);
+    std::vector<std::string> args(argv, argv + argc);
+    // Parse Node.js CLI options, and print any errors that have occurred while
+    // trying to parse them.
+    std::shared_ptr<node::InitializationResult> result =
+            node::InitializeOncePerProcess(args, {
+                    node::ProcessInitializationFlags::kNoInitializeV8,
+                    node::ProcessInitializationFlags::kNoInitializeNodeV8Platform
+            });
+
+    for (const std::string& error : result->errors())
+        fprintf(stderr, "%s: %s\n", args[0].c_str(), error.c_str());
+    if (result->early_return() != 0) {
+        return result->exit_code();
+    }
+
+    // Create a v8::Platform instance. `MultiIsolatePlatform::Create()` is a way
+    // to create a v8::Platform instance that Node.js can use when creating
+    // Worker threads. When no `MultiIsolatePlatform` instance is present,
+    // Worker threads are disabled.
+    std::unique_ptr<MultiIsolatePlatform> platform =
+            MultiIsolatePlatform::Create(4);
+    V8::InitializePlatform(platform.get());
+    V8::Initialize();
+
+    // See below for the contents of this function.
+    int ret = RunNodeInstance(
+            platform.get(), result->args(), result->exec_args());
+
+    V8::Dispose();
+    V8::DisposePlatform();
+
+    node::TearDownOncePerProcess();
+    return ret;
 }
 
 // Node's libUV requires all arguments being on contiguous memory.
@@ -163,10 +285,15 @@ Java_net_hampoelz_capacitor_nodejs_NodeProcess_nativeStart(
     cacheClassObject = object;
 
     // Start node, with argc and argv.
-    auto exitCode = node::Start(argumentCount, argv);
+    auto exitCode = RunNodeProcess(argumentCount, argv);
     free(argsBuffer);
 
     return jint(exitCode);
+}
+
+extern "C" void JNICALL
+Java_net_hampoelz_capacitor_nodejs_NodeProcess_nativeStop(JNIEnv *env, jobject thiz) {
+    node::Stop(nodeENV);
 }
 
 // Start threads to redirect stdout and stderr to logcat.

--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -107,6 +107,7 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
     std::vector<std::string> errors;
     std::unique_ptr<CommonEnvironmentSetup> setup =
             CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);
+
     if (!setup) {
         for (const std::string& err : errors)
             fprintf(stderr, "%s: %s\n", args[0].c_str(), err.c_str());
@@ -134,11 +135,11 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
         // load files from the disk, and uses the standard CommonJS file loader
         // instead of the internal-only `require` function.
         MaybeLocal<Value> loadenv_ret = node::LoadEnvironment(
-                nodeENV,
-                "const publicRequire ="
-                "  require('node:module').createRequire(process.cwd() + '/');"
-                "globalThis.require = publicRequire;"
-                "require('node:vm').runInThisContext(process.argv[1]);");
+            nodeENV,
+            [](const node::StartExecutionCallbackInfo &info) {
+                // Run main script with native require or start script execution
+                return info.native_require;
+            });
 
         if (loadenv_ret.IsEmpty())  // There has been a JS exception.
             return 1;
@@ -176,7 +177,7 @@ int RunNodeProcess(int argc, char** argv) {
     // Worker threads. When no `MultiIsolatePlatform` instance is present,
     // Worker threads are disabled.
     std::unique_ptr<MultiIsolatePlatform> platform =
-            MultiIsolatePlatform::Create(4);
+            MultiIsolatePlatform::Create(0);
     V8::InitializePlatform(platform.get());
     V8::Initialize();
 
@@ -292,7 +293,7 @@ Java_net_hampoelz_capacitor_nodejs_NodeProcess_nativeStart(
 }
 
 extern "C" void JNICALL
-Java_net_hampoelz_capacitor_nodejs_NodeProcess_nativeStop(JNIEnv *env, jobject thiz) {
+Java_net_hampoelz_capacitor_nodejs_NodeProcess_nativeStop(JNIEnv *env, jobject /*this*/) {
     node::Stop(nodeENV);
 }
 

--- a/android/src/main/java/net/hampoelz/capacitor/nodejs/CapacitorNodeJS.java
+++ b/android/src/main/java/net/hampoelz/capacitor/nodejs/CapacitorNodeJS.java
@@ -180,6 +180,10 @@ public class CapacitorNodeJS {
         engine.start();
     }
 
+    protected void stopEngine() {
+        nodeProcess.stop();
+    }
+
     protected void resolveWhenReady(PluginCall call) {
         if (!engineStatus.isStarted()) {
             call.reject("The Node.js engine has not been started yet.");

--- a/android/src/main/java/net/hampoelz/capacitor/nodejs/CapacitorNodeJSPlugin.java
+++ b/android/src/main/java/net/hampoelz/capacitor/nodejs/CapacitorNodeJSPlugin.java
@@ -55,13 +55,33 @@ public class CapacitorNodeJSPlugin extends Plugin {
     @Override
     protected void handleOnResume() {
         super.handleOnResume();
-        implementation.sendMessage(CapacitorNodeJSPlugin.CHANNEL_NAME_APP, "resume", new JSArray());
+        this.load();
     }
 
     @Override
     protected void handleOnPause() {
         super.handleOnPause();
         implementation.sendMessage(CapacitorNodeJSPlugin.CHANNEL_NAME_APP, "pause", new JSArray());
+        implementation.stopEngine();
+    }
+
+    @Override
+    protected void handleOnStop() {
+        super.handleOnStop();
+        implementation.stopEngine();
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        super.handleOnDestroy();
+        implementation.stopEngine();
+    }
+
+    @Override
+    protected void handleOnRestart() {
+        super.handleOnRestart();
+        implementation.stopEngine();
+        this.load();
     }
 
     //region PluginMethods

--- a/android/src/main/java/net/hampoelz/capacitor/nodejs/CapacitorNodeJSPlugin.java
+++ b/android/src/main/java/net/hampoelz/capacitor/nodejs/CapacitorNodeJSPlugin.java
@@ -52,11 +52,11 @@ public class CapacitorNodeJSPlugin extends Plugin {
         return settings;
     }
 
-    @Override
-    protected void handleOnResume() {
-        super.handleOnResume();
-        this.load();
-    }
+//    @Override
+//    protected void handleOnResume() {
+//        super.handleOnResume();
+//        this.load();
+//    }
 
     @Override
     protected void handleOnPause() {
@@ -65,24 +65,24 @@ public class CapacitorNodeJSPlugin extends Plugin {
         implementation.stopEngine();
     }
 
-    @Override
-    protected void handleOnStop() {
-        super.handleOnStop();
-        implementation.stopEngine();
-    }
-
-    @Override
-    protected void handleOnDestroy() {
-        super.handleOnDestroy();
-        implementation.stopEngine();
-    }
-
-    @Override
-    protected void handleOnRestart() {
-        super.handleOnRestart();
-        implementation.stopEngine();
-        this.load();
-    }
+//    @Override
+//    protected void handleOnStop() {
+//        super.handleOnStop();
+//        implementation.stopEngine();
+//    }
+//
+//    @Override
+//    protected void handleOnDestroy() {
+//        super.handleOnDestroy();
+//        implementation.stopEngine();
+//    }
+//
+//    @Override
+//    protected void handleOnRestart() {
+//        super.handleOnRestart();
+//        implementation.stopEngine();
+//        this.load();
+//    }
 
     //region PluginMethods
     //---------------------------------------------------------------------------------------

--- a/android/src/main/java/net/hampoelz/capacitor/nodejs/NodeProcess.java
+++ b/android/src/main/java/net/hampoelz/capacitor/nodejs/NodeProcess.java
@@ -16,6 +16,8 @@ public class NodeProcess {
 
     private native void nativeSend(String channelName, String message);
 
+    private native void nativeStop();
+
     /** @noinspection unused*/
     private void nativeReceive(String channelName, String message) {
         receiveCallback.receive(channelName, message);
@@ -49,6 +51,10 @@ public class NodeProcess {
         }
 
         nativeStart(arguments, environmentVariables, true);
+    }
+
+    protected void stop() {
+        nativeStop();
     }
 
     protected interface ReceiveCallback {


### PR DESCRIPTION
Since we don't Node.js explicitly I thought we could try stopping it whenever the app pauses and that would fix some other issues also.

The libnode uses the API provided by Node.js.

The plan was to:

1. Handle `pause`, `resume`, `stop`, `restart` events accordingly and manage how node.js runs
2. Implement a properly working `node::Stop` function
3. Call `node::Stop`
4. Start node faster

However, I realized that.

1. This won't fix our problem with backend loading after the frontend loads because the backend loads after the Plugin is registered and the Plugin is registered only after Capacitor is running and properly setup
2. I don't really understand how the API works and there's not a lot of docs about it
3. We are running C++ in the JNI layer so the static variables for the ENV might not work as expected
4. Or how do we store the ENV in Java or JS to for the `node::Stop()` to use 

https://nodejs.org/api/embedding.html#c-embedder-api